### PR TITLE
Attempting to fix page jumping

### DIFF
--- a/model/wd/index-renamed.html
+++ b/model/wd/index-renamed.html
@@ -291,7 +291,7 @@ The fundamental features of an Annotation are:
 
 <h4>Example</h4>
 
-<div class="nanotabs">
+<div class="nanotabs" style="height:360px">
 <ul>
   <li><a href="#tab_jsonld">JSON-LD</a></li>
   <li><a href="#tab_turtle">Turtle</a></li>
@@ -351,7 +351,7 @@ The datetime MUST be expressed in the <a href="http://www.w3.org/TR/xmlschema-2/
 
 <h4>Example</h4>
 
-<div class="nanotabs">
+<div class="nanotabs" style="height:405px">
 <ul>
   <li><a href="#tab_jsonld">JSON-LD</a></li>
   <li><a href="#tab_turtle">Turtle</a></li>


### PR DESCRIPTION
By specifying the right height of the tabs, the jumping is eliminated. However, it has to be done case by case.